### PR TITLE
Support DOCKER_REGISTRY_URL env var

### DIFF
--- a/cli/docker-ls/cmd_repositories.go
+++ b/cli/docker-ls/cmd_repositories.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"sync"
 
@@ -71,7 +72,7 @@ func (r *repositoriesCmd) execute(argv []string) (err error) {
 
 func (r *repositoriesCmd) listLevel0(api lib.RegistryApi) (resp *response.RepositoriesL0, err error) {
 	progress := NewProgressIndicator(r.cfg)
-	progress.Start("requesting list")
+	progress.Start(fmt.Sprintf("requesting list from %s", api.GetRegistryUrl()))
 
 	result := api.ListRepositories()
 	resp = response.NewRepositoriesL0()
@@ -90,7 +91,7 @@ func (r *repositoriesCmd) listLevel0(api lib.RegistryApi) (resp *response.Reposi
 
 func (r *repositoriesCmd) listLevel1(api lib.RegistryApi) (resp *response.RepositoriesL1, err error) {
 	progress := NewProgressIndicator(r.cfg)
-	progress.Start("requesting list")
+	progress.Start(fmt.Sprintf("requesting list from %s", api.GetRegistryUrl()))
 
 	repositoriesResult := api.ListRepositories()
 	resp = response.NewRepositoriesL1()

--- a/lib/api_interface.go
+++ b/lib/api_interface.go
@@ -1,6 +1,8 @@
 package lib
 
 import (
+	"net/url"
+
 	"github.com/mayflower/docker-ls/lib/connector"
 )
 
@@ -36,6 +38,7 @@ type TagDetails interface {
 }
 
 type RegistryApi interface {
+	GetRegistryUrl() *url.URL
 	ListRepositories() RepositoryListResponse
 	ListTags(repositoryName string) TagListResponse
 	GetTagDetails(ref Refspec, manifestVersion uint) (TagDetails, error)

--- a/lib/config.go
+++ b/lib/config.go
@@ -4,14 +4,24 @@ import (
 	"errors"
 	"flag"
 	"net/url"
+	"os"
 
 	"github.com/mayflower/docker-ls/lib/auth"
 )
 
 var DEFAULT_REGISTRY_URL url.URL
+var DEFAULT_REGISTRY_URL_STRING string
 
 func init() {
-	parsed, _ := url.Parse("https://index.docker.io")
+	initRegistryURL()
+}
+
+func initRegistryURL() {
+	DEFAULT_REGISTRY_URL_STRING = os.Getenv("DOCKER_REGISTRY_URL")
+	if DEFAULT_REGISTRY_URL_STRING == "" {
+		DEFAULT_REGISTRY_URL_STRING = "https://index.docker.io"
+	}
+	parsed, _ := url.Parse(DEFAULT_REGISTRY_URL_STRING)
 
 	DEFAULT_REGISTRY_URL = *parsed
 }

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -1,0 +1,26 @@
+package lib
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestInitRegistryURL(t *testing.T) {
+	initRegistryURL()
+
+	if DEFAULT_REGISTRY_URL_STRING != "https://index.docker.io" {
+		t.Fatal("Expected DEFAULT_REGISTRY_URL_STRING to be \"https://docker.mycompany.com\"")
+	}
+}
+
+func TestInitRegistryURLWithEnvVar(t *testing.T) {
+	customRegistryURLString := "https://docker.mycompany.com"
+	os.Setenv("DOCKER_REGISTRY_URL", customRegistryURLString)
+	initRegistryURL()
+	os.Unsetenv("DOCKER_REGISTRY_URL")
+
+	if DEFAULT_REGISTRY_URL_STRING != customRegistryURLString {
+		t.Fatal(fmt.Sprintf("Expected DEFAULT_REGISTRY_URL_STRING to be \"%s\"", customRegistryURLString))
+	}
+}

--- a/lib/registry_api.go
+++ b/lib/registry_api.go
@@ -13,6 +13,10 @@ type registryApi struct {
 	connector connector.Connector
 }
 
+func (r *registryApi) GetRegistryUrl() *url.URL {
+	return &r.cfg.registryUrl
+}
+
 func (r *registryApi) endpointUrl(path string) *url.URL {
 	url := r.cfg.registryUrl
 


### PR DESCRIPTION
If the environment variable `DOCKER_REGISTRY_URL` is set, then the value of it will be used as the default registry URL, instead of `"https://index.docker.io"`.

E.g.:

```
$ export DOCKER_REGISTRY_URL=https://docker.corp.surveymonkey.com
$ docker-ls repositories
requesting list from https://docker.corp.surveymonkey.com . done
repositories:
- acme/webhook
- admintools/admintools-nodejs-asset-build
- cx
...
```
