### PR TITLE
Add .travis.yml for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+go:
+  - 1.6.2
+
+install: make
+script:
+  - make test
+
+sudo: false


### PR DESCRIPTION
This aids in setting up [Travis CI](https://travis-ci.org/) for the project.

Before merging this PR, I recommend following the steps at https://docs.travis-ci.com/user/getting-started/ -- then when you merge this PR, a Travis CI build will be kicked off.

Sample passing Travis CI build for my fork: https://travis-ci.org/msabramo/docker-ls/builds/143202186
