### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:latest
+MAINTAINER Mayflower GmbH
+
+ADD . /go/src/github.com/mayflower/docker-ls
+WORKDIR /go/src/github.com/mayflower/docker-ls
+
+RUN make clean && make install && cp /go/src/github.com/mayflower/docker-ls/build/bin/* /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -14,12 +14,49 @@ are supported for authentication.
 
 # Installation
 
-Three ways there are to attain enlightenment.
+Four ways there are to attain enlightenment.
 
 ## Precompiled binaries
 
 Just download precompiled binaries for your platform from
 [github](https://github.com/mayflower/docker-ls/releases).
+
+## Docker
+
+If you have Docker installed, you may want to try this option. Clone the
+repository and do:
+
+    docker build -t docker-ls .
+
+Example of running container:
+
+    $ docker run -it docker-ls docker-ls tags library/consul
+    requesting list . done
+    repository: library/consul
+    tags:
+    - latest
+    - v0.6.4
+
+Or create aliases:
+
+    $ alias docker-ls='docker run -it docker-ls docker-ls'
+    $ alias docker-rm='docker run -it docker-ls docker-rm'
+
+So you can do:
+
+    $ docker-ls tags library/consul
+    requesting list . done
+    repository: library/consul
+    tags:
+    - latest
+    - v0.6.4
+
+and:
+
+    $ docker-rm | head -n 3
+    usage: docker-rm [options] <repository:reference>
+
+    Delete a tag in a given repository.
 
 ## Go get
 


### PR DESCRIPTION
This lets developers build and run the tools and doesn't require them to have Golang installed (though they of course have to have Docker installed).

To build the image:

```
$ docker build -t docker-ls .
```

Example of running container:

```
$ docker run -it docker-ls docker-ls tags library/consul
requesting list . done
repository: library/consul
tags:
- latest
- v0.6.4
```

Or create aliases:

```
$ alias docker-ls='docker run -it docker-ls docker-ls'
$ alias docker-rm='docker run -it docker-ls docker-rm'
```

So you can do:

```
$ docker-ls tags library/consul
requesting list . done
repository: library/consul
tags:
- latest
- v0.6.4
```

and:

```
$ docker-rm | head -n 3
usage: docker-rm [options] <repository:reference>

Delete a tag in a given repository.
```
