### PR TITLE
Smaller Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ ENV GOARCH=amd64
 ADD . /go/src/github.com/mayflower/docker-ls
 WORKDIR /go/src/github.com/mayflower/docker-ls
 RUN set -ex \
-  && go build github.com/mayflower/docker-ls/cli/docker-ls \
-  && go build github.com/mayflower/docker-ls/cli/docker-rm
+  && go generate  github.com/mayflower/docker-ls/lib/... \
+  && go build     github.com/mayflower/docker-ls/cli/docker-ls \
+  && go build     github.com/mayflower/docker-ls/cli/docker-rm
 
 # Target container that is produced by docker build
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
-FROM golang:latest
-MAINTAINER Mayflower GmbH
-
+# Build Container
+FROM golang:latest AS build
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
 ADD . /go/src/github.com/mayflower/docker-ls
 WORKDIR /go/src/github.com/mayflower/docker-ls
+RUN set -ex \
+  && go build github.com/mayflower/docker-ls/cli/docker-ls \
+  && go build github.com/mayflower/docker-ls/cli/docker-rm
 
-RUN go generate github.com/mayflower/docker-ls/lib/... && go install github.com/mayflower/docker-ls/cli/...
+# Target container that is produced by docker build
+FROM alpine:latest
+RUN set -ex \
+  && apk add --no-cache ca-certificates
+LABEL MAINTAINER="Mayflower GmbH"
+COPY --from=build /go/src/github.com/mayflower/docker-ls/docker-* /bin/


### PR DESCRIPTION
The existing Dockerfile produces a docker image that contains the entire build chain and as such is about 860MB in size
By compiling on one container and then packaging the compiled assets into a separate bare bones container the new container is just under 28MB in size