### PR TITLE
Use Travis CI for automatic Docker Container Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.travis.yml
+.gitignore
+*.md
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,42 @@
-language: go
+language: minimal
+dist: xenial
+addons:
+  apt:
+    sources:
+      - docker-xenial
+
+# Required Variables via Travis CI Project Page:
+# DOCKER_USER -> Username to login to hub.docker.com
+# DOCKER_PASS -> Password to loigin to hub.docker.com
+# DOCKER_REPO -> Image + Repository Name: example/docker-ls
+
+env:
+  ADD_TAG="latest"
+
+before_install:
+# Pull Kaniko Image
+- docker pull gcr.io/kaniko-project/executor:latest
+# Add docker-retag executable
+- wget -q https://github.com/joshdk/docker-retag/releases/download/0.0.2/docker-retag && chmod +x docker-retag
+# Login to hub.docker.com
+- echo "$DOCKER_PASS" | docker login -u $DOCKER_USER --password-stdin
+
+script:
+# Build Image via kaniko
+- docker run
+    -v "$TRAVIS_BUILD_DIR":/workspace
+    -v $HOME/.docker:/kaniko/.docker
+  gcr.io/kaniko-project/executor:latest
+    --context=/workspace
+    --verbosity=info
+    --destination=$DOCKER_REPO:$TRAVIS_COMMIT
+
+# Retag image for other tags
+- for i in "$ADD_TAG $TRAVIS_TAG";
+  do
+    ./docker-retag $DOCKER_REPO:$TRAVIS_COMMIT $i;
+  done
+
+# # don't notify me when things fail
+# notifications:
+#   email: false


### PR DESCRIPTION
Hi,
I like your solution. But there is no automatic builded Docker container.
So I decided to improve your Travis CI configuration to build and push an Docker container.

But it can only work if you do the following:
- Go to https://travis-ci.org/mayflower/docker-ls and activate docker-ls project
- Add DOCKER_USER, DOCKER_PASS and DOCKER_REPO as project environment variables.
  DOCKER_USER = hub.docker.com username
  DOCKER_PASS = hub.docker.com password
 DOCKER_REPO = hub.docker.com repository + image -> 8ear/docker-ls
- Add Travis CI cron job:
  Branch: Master
  Interval: Daily | Weekly
- Change the Travis CI Badge at Readme.md to your Repository.

As an alternative you can also setup an automatic build at hub.docker.com, but this one is less configurable. But then you does not require to add you hub.docker.com user and password to Travis CI.


Now it is ready and you can merge this pull request in your master.