### PR TITLE
Initial Debug Logging

### DIFF
--- a/cli/docker-ls/cmd_root.go
+++ b/cli/docker-ls/cmd_root.go
@@ -1,14 +1,29 @@
 package main
 
 import (
+	"log"
+	"os"
+
 	"github.com/mayflower/docker-ls/cli/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+var debug bool
 
 var rootCmd = &cobra.Command{
 	Use:   "docker-ls",
 	Short: "browse docker registries",
 	Long:  "Browse and examine repositories and tags in a docker registry",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		viper.BindPFlags(cmd.Flags())
+
+		if debug {
+			log.SetOutput(os.Stdout)
+			log.SetFlags(log.LstdFlags | log.Lshortfile)
+			log.Printf("debug logging enabled")
+		}
+	},
 }
 
 func init() {
@@ -16,6 +31,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "",
 		"read config from specified file (default: look for config in home directory)",
 	)
+	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "emit debugging logs")
 
 	util.SetupViper(configFile)
 }

--- a/cli/docker-ls/cmd_tags.go
+++ b/cli/docker-ls/cmd_tags.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/viper"
-
 	"github.com/mayflower/docker-ls/cli/docker-ls/tags"
 	"github.com/mayflower/docker-ls/cli/util"
 	"github.com/mayflower/docker-ls/lib"
@@ -17,7 +15,6 @@ var tagsCmd = &cobra.Command{
 	Short: "List tags",
 	Long:  "List all tags for a repository",
 	Run: func(cmd *cobra.Command, args []string) {
-		viper.BindPFlags(cmd.Flags())
 
 		var err error
 

--- a/cli/docker-ls/main.go
+++ b/cli/docker-ls/main.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 )
 
 func main() {
+	log.SetOutput(ioutil.Discard)
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/cli v20.10.0-rc2+incompatible h1:73l5MIRAmVzWD2GQ3XrHYvSOz4FXy1l7URwy35PS6bs=

--- a/lib/api_tag_list.go
+++ b/lib/api_tag_list.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 )
 
@@ -48,6 +49,7 @@ func (r *tagListRequestContext) path() string {
 }
 
 func (r *tagListRequestContext) validateApiResponse(response *http.Response, initialRequest bool) error {
+	log.Printf("api response: %#v", response)
 	switch response.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return genericAuthorizationError

--- a/lib/config.go
+++ b/lib/config.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"errors"
 	"flag"
+	"log"
 	"net/url"
 
 	"github.com/mayflower/docker-ls/lib/auth"
@@ -125,6 +126,7 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) LoadCredentialsFromDockerConfig() {
+	log.Printf("load credentials? %t", c.credentials.IsBlank())
 	if c.credentials.IsBlank() {
 		c.credentials.LoadCredentialsFromDockerConfig(c.registryUrl)
 	}

--- a/lib/registry_credentials.go
+++ b/lib/registry_credentials.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"flag"
+	"log"
 	"net/url"
 	"os"
 
@@ -44,11 +45,14 @@ func (r *RegistryCredentials) IsBlank() bool {
 }
 
 func (r *RegistryCredentials) LoadCredentialsFromDockerConfig(url url.URL) {
-	authConfig, err := config.LoadDefaultConfigFile(os.Stderr).GetCredentialsStore(url.Host).Get(url.Host)
+	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
+	log.Printf("docker config: %#v", dockerConfig)
+	authConfig, err := dockerConfig.GetCredentialsStore(url.Host).Get(url.Host)
 
 	if err != nil {
 		return
 	}
+	log.Printf("docker credentials: %#v", authConfig)
 
 	if authConfig.IdentityToken != "" {
 		r.identityToken = authConfig.IdentityToken


### PR DESCRIPTION
Adds a `--debug` flag, which enables logging via the stdlib `log` package.
Adds a couple of log entries, which I needed to figure out why auth wasn't happening for me.

If this is accepable, future PRs would add further entries.
